### PR TITLE
parent's spending graph for children fixed upon load

### DIFF
--- a/client/components/parentComponents/ChildCard.jsx
+++ b/client/components/parentComponents/ChildCard.jsx
@@ -88,6 +88,7 @@ const ModalItem = ({ kid }) => {
   const [display, setDisplay] = useState('none');
   const [newAllowance, setNewAllowance] = useState(kid.allowance);
   const [newInterval, setNewInterval] = useState(kid.allowanceInterval);
+  const [isChanged, setIsChanged] = useState(false);
   let props = { display: display };
   const styles = useModalStyles(props);
   const handleSubmit = async (evt) => {
@@ -97,6 +98,7 @@ const ModalItem = ({ kid }) => {
       newAllowance,
       newInterval,
     });
+    setIsChanged(true);
     setDisplay('none');
   };
   const handleChange = (evt) => {
@@ -104,6 +106,16 @@ const ModalItem = ({ kid }) => {
       ? setNewAllowance(evt.target.value)
       : setNewInterval(evt.target.value);
   };
+  // useEffect(() => {
+  //   return (
+  //     async () => {
+  //       if (isChanged) {
+  //         setIsChanged(false);
+  //       }
+  //     },
+  //     []
+  //   );
+  // });
   return (
     <div>
       <Button
@@ -139,6 +151,13 @@ const ModalItem = ({ kid }) => {
     </div>
   );
 };
+const AllowanceItem = ({ kid }) => {
+  return (
+    <div>
+      Allowance in {kid.daysToAllowance} days: ${kid.allowance}
+    </div>
+  );
+};
 const PersonItem = ({ src, name, balance, selectedKid, kid }) => {
   const avatarStyles = useDynamicAvatarStyles({ size: 100 });
   const styles = usePersonStyles();
@@ -155,9 +174,7 @@ const PersonItem = ({ src, name, balance, selectedKid, kid }) => {
           </div>
         </Item>
         <Item position={'middle'}>
-          <div>
-            Allowance in {kid.allowanceInterval} days: ${kid.allowance}
-          </div>
+          <AllowanceItem kid={kid}></AllowanceItem>
           <ModalItem kid={kid} />
           <AliasLink to={{ pathname: '/chores', state: { selectedKid } }}>
             <Button className={styles.btn} variant={'outlined'}>
@@ -199,17 +216,8 @@ const useStyles = makeStyles(() => ({
     margin: '0 20px',
   },
 }));
-const getTransactions = async (id) => {
-  const response = await axios.get(`/api/transaction/${id}`);
-  const kidTransactions = response.data;
-  return kidTransactions;
-};
 const ChildCard = React.memo(function SocialCard(props) {
   const styles = useStyles();
-  props.kids.map(async (kid) => {
-    kid.transactions = await getTransactions(kid.id);
-    return kid;
-  });
   return (
     <>
       <NoSsr>
@@ -220,10 +228,6 @@ const ChildCard = React.memo(function SocialCard(props) {
           <Item stretched className={styles.headline}>
             Your kids:
           </Item>
-          {/* <Item className={styles.actions}>
-            <Link className={styles.link}>Refresh</Link> •{' '}
-            <Link className={styles.link}>See all</Link>
-          </Item> */}
         </Row>
         {props.kids.map((kid) => {
           return (

--- a/client/components/parentComponents/ChildCard.jsx
+++ b/client/components/parentComponents/ChildCard.jsx
@@ -13,6 +13,7 @@ import { useDynamicAvatarStyles } from '@mui-treasury/styles/avatar/dynamic';
 import { connect } from 'react-redux';
 import SpendingGraph from '../child components/SpendingGraph';
 import axios from 'axios';
+import { getKids } from '../../store/actions/parentActions/getKids';
 
 const usePersonStyles = makeStyles(() => ({
   text: {
@@ -84,7 +85,7 @@ const useModalStyles = makeStyles((props) => ({
   },
 }));
 
-const ModalItem = ({ kid }) => {
+const ModalItem = ({ kid, userID, getKids }) => {
   const [display, setDisplay] = useState('none');
   const [newAllowance, setNewAllowance] = useState(kid.allowance);
   const [newInterval, setNewInterval] = useState(kid.allowanceInterval);
@@ -93,12 +94,14 @@ const ModalItem = ({ kid }) => {
   const styles = useModalStyles(props);
   const handleSubmit = async (evt) => {
     evt.preventDefault();
-    console.log(kid);
+    // console.log(kid);
     await axios.put(`/api/users/allowance/modify/${kid.id}`, {
       newAllowance,
       newInterval,
     });
     setIsChanged(true);
+    console.log(userID);
+    getKids(userID);
     setDisplay('none');
   };
   const handleChange = (evt) => {
@@ -158,7 +161,15 @@ const AllowanceItem = ({ kid }) => {
     </div>
   );
 };
-const PersonItem = ({ src, name, balance, selectedKid, kid }) => {
+const PersonItem = ({
+  src,
+  name,
+  balance,
+  selectedKid,
+  kid,
+  userID,
+  getKids,
+}) => {
   const avatarStyles = useDynamicAvatarStyles({ size: 100 });
   const styles = usePersonStyles();
   return (
@@ -174,8 +185,8 @@ const PersonItem = ({ src, name, balance, selectedKid, kid }) => {
           </div>
         </Item>
         <Item position={'middle'}>
-          <AllowanceItem kid={kid}></AllowanceItem>
-          <ModalItem kid={kid} />
+          <AllowanceItem kid={kid} userID={userID}></AllowanceItem>
+          <ModalItem kid={kid} userID={userID} getKids={getKids} />
           <AliasLink to={{ pathname: '/chores', state: { selectedKid } }}>
             <Button className={styles.btn} variant={'outlined'}>
               Assigned Chores
@@ -238,6 +249,8 @@ const ChildCard = React.memo(function SocialCard(props) {
                 src={kid.imgUrl}
                 selectedKid={kid}
                 kid={kid}
+                userID={props.userID}
+                getKids={props.getKids}
               />
               <SpendingGraph transactions={kid.transactions} />
               <Divider variant={'middle'} className={styles.divider} />
@@ -248,5 +261,9 @@ const ChildCard = React.memo(function SocialCard(props) {
     </>
   );
 });
-
-export default connect()(ChildCard);
+const mapDispatchToProps = (dispatch) => {
+  return {
+    getKids: (id) => dispatch(getKids(id)),
+  };
+};
+export default connect(null, mapDispatchToProps)(ChildCard);

--- a/client/components/parentComponents/ParentLandingPage.jsx
+++ b/client/components/parentComponents/ParentLandingPage.jsx
@@ -5,21 +5,14 @@ import ChildCard from './ChildCard';
 export class ParentLandingPage extends Component {
   constructor() {
     super();
-    this.getKids = this.getKids.bind(this);
   }
   componentDidMount() {}
   componentDidUpdate() {}
-  getKids() {
-    const kids = this.props.user.family.users.filter(
-      (member) => member.status === 'Child'
-    );
-    return kids;
-  }
   render() {
     return this.props.user.family ? (
       <div>
         <div>Hello {this.props.user.firstName}</div>
-        <ChildCard kids={this.getKids()} />
+        <ChildCard kids={this.props.kids} />
       </div>
     ) : (
       ''
@@ -30,6 +23,9 @@ export class ParentLandingPage extends Component {
 const mapStateToProps = (state) => {
   return {
     user: state.currUser,
+    kids: state.currUser.family?.users.filter(
+      (member) => member.status === 'Child'
+    ),
   };
 };
 export default connect(mapStateToProps)(ParentLandingPage);

--- a/client/components/parentComponents/ParentLandingPage.jsx
+++ b/client/components/parentComponents/ParentLandingPage.jsx
@@ -12,7 +12,7 @@ export class ParentLandingPage extends Component {
     return this.props.user.family ? (
       <div>
         <div>Hello {this.props.user.firstName}</div>
-        <ChildCard kids={this.props.kids} />
+        <ChildCard kids={this.props.kids} userID={this.props.user.id} />
       </div>
     ) : (
       ''
@@ -23,9 +23,7 @@ export class ParentLandingPage extends Component {
 const mapStateToProps = (state) => {
   return {
     user: state.currUser,
-    kids: state.currUser.family?.users.filter(
-      (member) => member.status === 'Child'
-    ),
+    kids: state.kids,
   };
 };
 export default connect(mapStateToProps)(ParentLandingPage);

--- a/server/api/users.js
+++ b/server/api/users.js
@@ -29,7 +29,13 @@ router.get('/:id', async (req, res, next) => {
         include: [
           { model: Transaction },
           // { model: Allowance },
-          { model: Family, include: [User] },
+          {
+            model: Family,
+            include: {
+              model: User,
+              include: { model: Transaction },
+            },
+          },
         ],
       })
     );
@@ -143,6 +149,8 @@ router.put('/allowance/modify/:id', async (req, res, next) => {
     console.log(newInterval);
     user.allowance = newAllowance;
     user.allowanceInterval = newInterval;
+    //check if new allowance interval is less than days to current allowance
+    if (user.daysToAllowance > newInterval) user.daysToAllowance = newInterval;
     await user.save();
     console.log(user);
     res.status(201).send(user);


### PR DESCRIPTION
Children's spending graph's on parent merge page now loads all the time without needing to refresh the page